### PR TITLE
YOMA-586 - feat(Experience): fix metadata properties on selector

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -140,7 +140,7 @@ android {
         applicationId "com.yomamobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 36
+        versionCode 37
         versionName "0.0.1"
         multiDexEnabled true
     }

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,9 +1,10 @@
 Ver 0.0.1
 Latest:
-- adding generic MyCv View component (with a bunch of refactoring)
+- adding metadata for countries and duration to job experience
 
 10 Most Recent:
--adding user qualifications to state
+- adding generic MyCv View component (with a bunch of refactoring)
+- adding user qualifications to state
 - refactor: renaming createMiddlewareStub
 - moving my cv views out of user credential modules
 - refactor - pascal casing all type enums
@@ -12,4 +13,3 @@ Latest:
 - experience - save new/edited experience to backend
 - experience should correctly show all the user's entries
 - adding real data to UserChallenges widget in MyCv
-- updating UserChallenges widget component

--- a/src/components/CvView/Credential/CvViewCredential.styles.ts
+++ b/src/components/CvView/Credential/CvViewCredential.styles.ts
@@ -5,13 +5,13 @@ import * as StyleUtils from '../../../styles/styles.utils'
 
 const styles = {
   container: {
-    ...StyleUtils.dropShadow(5.14, 5.14, 23.14, Colors.PrimaryDarkGrey, 7),
-    padding: 10,
+    padding: 14,
     borderRadius: 12,
     backgroundColor: colors[Colors.White],
     marginHorizontal: 10,
     marginBottom: 12,
     minHeight: 80,
+    ...StyleUtils.dropShadow(5.14, 5.14, 23.14, Colors.PrimaryDarkGrey, 7),
   } as ViewStyle,
   description: {
     marginTop: 7,

--- a/src/components/CvView/Credential/CvViewCredential.tsx
+++ b/src/components/CvView/Credential/CvViewCredential.tsx
@@ -10,12 +10,12 @@ interface Props extends React.ComponentProps<typeof CvViewCredentialHeader> {
   description?: string
 }
 
-const CvViewCredential = ({ description, iconUrl, subtitle, title, isValidated, onEdit }: Props) => {
+const CvViewCredential = ({ description, iconUrl, metadata, title, isValidated, onEdit }: Props) => {
   return (
     <View style={styles.container}>
       <CvViewCredentialHeader
         title={title}
-        subtitle={subtitle}
+        metadata={metadata}
         iconUrl={iconUrl}
         isValidated={isValidated}
         onEdit={onEdit}

--- a/src/components/CvView/Credential/CvViewCredentialHeader.styles.ts
+++ b/src/components/CvView/Credential/CvViewCredentialHeader.styles.ts
@@ -3,8 +3,6 @@ import { StyleSheet, ViewStyle } from 'react-native'
 const styles = {
   container: {
     flexDirection: 'row',
-    marginTop: 0,
-    marginBottom: 0,
   } as ViewStyle,
   content: {
     marginLeft: 12,

--- a/src/components/CvView/Credential/CvViewCredentialHeader.styles.ts
+++ b/src/components/CvView/Credential/CvViewCredentialHeader.styles.ts
@@ -3,7 +3,8 @@ import { StyleSheet, ViewStyle } from 'react-native'
 const styles = {
   container: {
     flexDirection: 'row',
-    marginTop: 5,
+    marginTop: 0,
+    marginBottom: 0,
   } as ViewStyle,
   content: {
     marginLeft: 12,

--- a/src/components/CvView/Credential/CvViewCredentialHeader.tsx
+++ b/src/components/CvView/Credential/CvViewCredentialHeader.tsx
@@ -9,18 +9,18 @@ import styles from './CvViewCredentialHeader.styles'
 
 interface Props {
   title: string
-  subtitle?: string[] | string
+  metadata?: string[] | string
   iconUrl: string
   isValidated: boolean
   onEdit: () => void
 }
 
-const CvViewCredentialHeader = ({ iconUrl, subtitle = [], title, isValidated, onEdit }: Props) => {
+const CvViewCredentialHeader = ({ iconUrl, metadata = [], title, isValidated, onEdit }: Props) => {
   const [subtitleArray, setSubtitleArray] = useState<string[]>([])
 
   useEffect(() => {
-    setSubtitleArray(Array.isArray(subtitle) ? subtitle : [subtitle])
-  }, [subtitle])
+    setSubtitleArray(Array.isArray(metadata) ? metadata : [metadata])
+  }, [metadata])
 
   return (
     <View style={styles.container}>

--- a/src/components/CvView/Credential/CvViewCredentialHeader.tsx
+++ b/src/components/CvView/Credential/CvViewCredentialHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { View } from 'react-native'
 
 import { Colors } from '../../../styles'
@@ -9,20 +9,13 @@ import styles from './CvViewCredentialHeader.styles'
 
 interface Props {
   title: string
-  metadata?: string[] | string
+  metadata?: string[]
   iconUrl: string
   isValidated: boolean
   onEdit: () => void
 }
 
 const CvViewCredentialHeader = ({ iconUrl, metadata = [], title, isValidated, onEdit }: Props) => {
-  const [subtitleArray, setSubtitleArray] = useState<string[]>([])
-
-  useEffect(() => {
-    console.log({ metadata })
-    setSubtitleArray(Array.isArray(metadata) ? metadata : [metadata])
-  }, [metadata])
-
   return (
     <View style={styles.container}>
       <Avatar name={title} url={iconUrl} isValidated={isValidated} />
@@ -30,7 +23,7 @@ const CvViewCredentialHeader = ({ iconUrl, metadata = [], title, isValidated, on
         <Text.Header level={HeaderLevels.H6} color={Colors.PrimaryDarkGrey}>
           {title}
         </Text.Header>
-        {subtitleArray.map(text => (
+        {metadata.map(text => (
           <Text.Body level={BodyLevels.Small} color={Colors.MenuGrey}>
             {text}
           </Text.Body>

--- a/src/components/CvView/Credential/CvViewCredentialHeader.tsx
+++ b/src/components/CvView/Credential/CvViewCredentialHeader.tsx
@@ -19,6 +19,7 @@ const CvViewCredentialHeader = ({ iconUrl, metadata = [], title, isValidated, on
   const [subtitleArray, setSubtitleArray] = useState<string[]>([])
 
   useEffect(() => {
+    console.log({ metadata })
     setSubtitleArray(Array.isArray(metadata) ? metadata : [metadata])
   }, [metadata])
 

--- a/src/components/CvView/CvView.tsx
+++ b/src/components/CvView/CvView.tsx
@@ -21,7 +21,7 @@ const CvView = ({ title, noDataMessage, onAdd, navigation, children }: Props) =>
   return (
     <ViewContainer style={styles.container}>
       <Header navigation={navigation} headerText={title} actionItem={<ButtonAdd onPress={onAdd} />} />
-      <Optional condition={!!children} fallback={<EmptyCard title={noDataMessage} onAdd={onAdd} />}>
+      <Optional condition={!!children} fallback={<EmptyCard title={noDataMessage} onPress={onAdd} />}>
         {children}
       </Optional>
     </ViewContainer>

--- a/src/components/EmptyCard/EmptyCard.tsx
+++ b/src/components/EmptyCard/EmptyCard.tsx
@@ -11,10 +11,10 @@ import styles from './EmptyCard.styles'
 
 type Props = {
   title: string
-  onAdd: () => void
+  onPress: () => void
 }
 
-const EmptyCard = ({ title, onAdd }: Props) => {
+const EmptyCard = ({ title, onPress }: Props) => {
   const { t } = useTranslation()
   return (
     <View style={styles.container}>
@@ -29,7 +29,7 @@ const EmptyCard = ({ title, onAdd }: Props) => {
       <Text.Body style={styles.text} color={Colors.PrimaryDarkGrey} align={TextAlign.Center}>
         {title}
       </Text.Body>
-      <Button size={ButtonSizes.Slim} label={t('Add')} onPress={onAdd} style={styles.button} />
+      <Button size={ButtonSizes.Slim} label={t('Add')} onPress={onPress} style={styles.button} />
     </View>
   )
 }

--- a/src/constants/date.constants.ts
+++ b/src/constants/date.constants.ts
@@ -1,1 +1,3 @@
 export const DATE_TPL_MON_YEAR = 'MMM yyyy'
+export const DATES_DIVIDER = '-'
+export const DATE_DURATION_DIVIDER = '•'

--- a/src/modules/CompletedCourses/CompletedCourses.constants.ts
+++ b/src/modules/CompletedCourses/CompletedCourses.constants.ts
@@ -1,7 +1,7 @@
 export const MOCK_COURSES = [
   {
     id: 1,
-    subtitle: 'Beyond your future challenge',
+    metadata: ['Beyond your future challenge'],
     iconUrl: '',
     isValidated: true,
     title: '',

--- a/src/modules/CompletedCourses/CompletedCourses.tsx
+++ b/src/modules/CompletedCourses/CompletedCourses.tsx
@@ -39,7 +39,7 @@ const CompletedCourses = ({ navigation }: Props) => {
         fallback={
           <Optional
             condition={MOCK_COURSES.length > 0}
-            fallback={<EmptyCard title={t('Have you completed any courses yet?')} onAdd={() => setIsEditing(true)} />}
+            fallback={<EmptyCard title={t('Have you completed any courses yet?')} onPress={() => setIsEditing(true)} />}
           >
             <FlatList
               data={MOCK_COURSES}

--- a/src/modules/Education/Education.constants.ts
+++ b/src/modules/Education/Education.constants.ts
@@ -3,7 +3,7 @@ export const NORMALISED_EDUCATION_MOCK = {
   entities: {
     id1: {
       id: 1,
-      subtitle: 'BA Degree',
+      metadata: ['BA Degree'],
       iconUrl: '',
       title: 'Rhodes University',
       description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ',
@@ -11,7 +11,7 @@ export const NORMALISED_EDUCATION_MOCK = {
     },
     id2: {
       id: 2,
-      subtitle: 'Matric',
+      metadata: ['Matric'],
       iconUrl: '',
       title: 'South Africa',
       description: '',

--- a/src/modules/Experience/Experience.selector.test.ts
+++ b/src/modules/Experience/Experience.selector.test.ts
@@ -1,15 +1,20 @@
 import { rootStateFixture } from '../../redux/redux.test.fixtures'
-import { USER_JOBS_MOCK } from '../UserJobs/UserJobs.test.fixtures'
+import { USER_JOBS_NORMALISED_MOCK } from '../UserJobs/UserJobs.test.fixtures'
 import * as SUT from './Experience.selector'
 
 describe('modules/Experience/Experience.selector', () => {
   describe('selectUserJobItems', () => {
-    it('should return userJobsItems from userJobs state', () => {
+    it('should handle an empty state', () => {
+      const stateMock = rootStateFixture()
+      const result = SUT.selectUserJobItems(stateMock)
+      expect(result).toEqual({
+        ids: [],
+        entities: {},
+      })
+    })
+    it('should return the correct items for the Experience View list', () => {
       const stateMock = rootStateFixture({
-        userJobs: {
-          ids: ['11111-5717-4562-b3fc-2c963f66afa6'],
-          entities: { '11111-5717-4562-b3fc-2c963f66afa6': USER_JOBS_MOCK[0] },
-        },
+        userJobs: USER_JOBS_NORMALISED_MOCK,
       })
       // when ... we call the selector
       // @ts-ignore
@@ -21,7 +26,7 @@ describe('modules/Experience/Experience.selector', () => {
         entities: {
           '11111-5717-4562-b3fc-2c963f66afa6': {
             title: 'TITLE',
-            subtitle: 'NAME',
+            metadata: ['NAME', 'Jun 2021 - Aug 2021 • 2 months', 'COUNTRY'],
             iconUrl: 'LOGO',
             isValidated: true,
             description: 'DESCRIPTION',
@@ -49,20 +54,7 @@ describe('modules/Experience/Experience.selector', () => {
     })
     it('should return userJobs, skills and organisations lists', () => {
       const mockState = rootStateFixture({
-        userJobs: {
-          ids: ['id1'],
-          entities: {
-            id1: {
-              approved: true,
-              job: {
-                title: 'TITLE',
-                description: 'DESCRIPTION',
-                organisationName: 'NAME',
-                organisationLogoURL: 'LOGO',
-              },
-            },
-          },
-        },
+        userJobs: USER_JOBS_NORMALISED_MOCK,
         skills: {
           ids: ['key1'],
           entities: { key1: { key: 'key1', value: 'skill' } },
@@ -78,11 +70,11 @@ describe('modules/Experience/Experience.selector', () => {
       // then ... should return the data required by the experience view
       expect(result).toEqual({
         userJobs: {
-          ids: ['id1'],
+          ids: ['11111-5717-4562-b3fc-2c963f66afa6'],
           entities: {
-            id1: {
+            '11111-5717-4562-b3fc-2c963f66afa6': {
               title: 'TITLE',
-              subtitle: 'NAME',
+              metadata: ['NAME', 'Jun 2021 - Aug 2021 • 2 months', 'COUNTRY'],
               iconUrl: 'LOGO',
               isValidated: true,
               description: 'DESCRIPTION',

--- a/src/modules/Experience/Experience.selector.ts
+++ b/src/modules/Experience/Experience.selector.ts
@@ -5,17 +5,17 @@ import { CvViewCredentialTypes } from '../../components/CvView'
 import * as OrganisationsSelectors from '../Organisations/Organisations.selector'
 import * as SkillsSelectors from '../Skills/Skills.selector'
 import { selectUserJobs } from '../UserJobs/UserJobs.selector'
+import { getExperienceMetadata } from './Experience.utils'
 
 export const selectUserJobItems = createSelector<any, any, CvViewCredentialTypes.CvViewCredentialsData>(
   selectUserJobs,
   jobs => {
-    // TODO: fix this to pass correct data (includes company, countries and period for job)
     const ids = jobs.ids
     const entities = map(
       pipe(
         applySpec({
           title: pathOr('', ['job', 'title']),
-          subtitle: pathOr('', ['job', 'organisationName']),
+          metadata: getExperienceMetadata,
           description: pathOr('', ['job', 'description']),
           iconUrl: path(['job', 'organisationLogoURL']),
           isValidated: propOr(false, 'approved'),

--- a/src/modules/Experience/Experience.utils.test.ts
+++ b/src/modules/Experience/Experience.utils.test.ts
@@ -1,4 +1,4 @@
-import { pick } from 'ramda'
+import { mergeDeepRight, pick } from 'ramda'
 
 import { USER_JOBS_MOCK } from '../UserJobs/UserJobs.test.fixtures'
 import * as SUT from './Experience.utils'
@@ -18,6 +18,12 @@ describe('modules/Experience/Experience.utils', () => {
       const result = SUT.getExperienceMetadata(USER_JOBS_MOCK[0])
 
       expect(result).toStrictEqual(['NAME', 'Jun 2021 - Aug 2021 • 2 months', 'COUNTRY'])
+    })
+    it('should correctly handle if a property is empty', () => {
+      const result = SUT.getExperienceMetadata(mergeDeepRight(USER_JOBS_MOCK[0], { job: { countries: undefined } }))
+      console.log(result)
+      expect(result.length).toBe(2)
+      expect(result).toStrictEqual(['NAME', 'Jun 2021 - Aug 2021 • 2 months'])
     })
   })
   describe('extractUserJobsFormValues', () => {

--- a/src/modules/Experience/Experience.utils.test.ts
+++ b/src/modules/Experience/Experience.utils.test.ts
@@ -1,7 +1,25 @@
+import { pick } from 'ramda'
+
 import { USER_JOBS_MOCK } from '../UserJobs/UserJobs.test.fixtures'
 import * as SUT from './Experience.utils'
 
 describe('modules/Experience/Experience.utils', () => {
+  describe('formatStartEndDatesWithDuration', () => {
+    it('should return the date period as well as the interval length', () => {
+      const durationTimestamps = pick(['startDate', 'endDate'])(USER_JOBS_MOCK[0])
+
+      const result = SUT.formatDurationString(durationTimestamps)
+
+      expect(result).toBe('Jun 2021 - Aug 2021 • 2 months')
+    })
+  })
+  describe('getExperienceMetadata', () => {
+    it('should return the required metadata from a User Job Credential', () => {
+      const result = SUT.getExperienceMetadata(USER_JOBS_MOCK[0])
+
+      expect(result).toStrictEqual(['NAME', 'Jun 2021 - Aug 2021 • 2 months', 'COUNTRY'])
+    })
+  })
   describe('extractUserJobsFormValues', () => {
     it('should return UserJobs form values from job credential payload', () => {
       //given ...

--- a/src/modules/Experience/Experience.utils.ts
+++ b/src/modules/Experience/Experience.utils.ts
@@ -1,5 +1,20 @@
 import { format } from 'date-fns/fp'
-import { always, apply, applySpec, compose, join, path, pathOr, pick, pipe, prop, props, values } from 'ramda'
+import {
+  always,
+  apply,
+  applySpec,
+  compose,
+  isEmpty,
+  join,
+  path,
+  pathOr,
+  pick,
+  pipe,
+  prop,
+  props,
+  reject,
+  values,
+} from 'ramda'
 
 import { DATES_DIVIDER, DATE_DURATION_DIVIDER, DATE_TPL_MON_YEAR } from '../../constants/date.constants'
 import { formatIntervalToDuration, newDate } from '../../utils/dates.utils'
@@ -34,4 +49,5 @@ export const getExperienceMetadata = pipe(
     countries: compose(join(', '), pathOr([], ['job', 'countries'])),
   }),
   values,
+  reject(isEmpty),
 )

--- a/src/modules/Experience/Experience.utils.ts
+++ b/src/modules/Experience/Experience.utils.ts
@@ -1,4 +1,8 @@
-import { applySpec, path, pathOr, prop } from 'ramda'
+import { format } from 'date-fns/fp'
+import { always, apply, applySpec, compose, join, path, pathOr, pick, pipe, prop, props, values } from 'ramda'
+
+import { DATES_DIVIDER, DATE_DURATION_DIVIDER, DATE_TPL_MON_YEAR } from '../../constants/date.constants'
+import { formatIntervalToDuration, newDate } from '../../utils/dates.utils'
 
 export const extractUserJobsFormValues = applySpec({
   id: path(['job', 'id']),
@@ -9,3 +13,25 @@ export const extractUserJobsFormValues = applySpec({
   startTime: prop('startDate'),
   endTime: prop('endDate'),
 })
+
+type FormatDurationString = (args: { startDate: string; endDate: string }) => string
+export const formatDurationString: FormatDurationString = pipe(
+  applySpec({
+    start: compose(format(DATE_TPL_MON_YEAR), newDate, prop('startDate')),
+    datesDivider: always(DATES_DIVIDER),
+    end: compose(format(DATE_TPL_MON_YEAR), newDate, prop('endDate')),
+    durationDivider: always(DATE_DURATION_DIVIDER),
+    period: compose(apply(formatIntervalToDuration), values),
+  }),
+  props(['start', 'datesDivider', 'end', 'durationDivider', 'period']),
+  join(' '),
+)
+
+export const getExperienceMetadata = pipe(
+  applySpec({
+    organisation: pathOr(null, ['job', 'organisationName']),
+    duration: compose(formatDurationString, pick(['startDate', 'endDate'])),
+    countries: compose(join(', '), pathOr([], ['job', 'countries'])),
+  }),
+  values,
+)

--- a/src/modules/MySkills/MySkills.tsx
+++ b/src/modules/MySkills/MySkills.tsx
@@ -40,7 +40,7 @@ const MySkills = ({ navigation }: Props) => {
         fallback={
           <Optional
             condition={MOCK_SKILLS.length > 0}
-            fallback={<EmptyCard title={t('Tell us what you are great at.')} onAdd={() => setIsEditing(true)} />}
+            fallback={<EmptyCard title={t('Tell us what you are great at.')} onPress={() => setIsEditing(true)} />}
           >
             <Card style={styles.outerCard}>
               <FlatList

--- a/src/utils/dates.utils.test.ts
+++ b/src/utils/dates.utils.test.ts
@@ -23,14 +23,14 @@ describe('dates.utils', () => {
     })
   })
 
-  describe('calculateDifferenceInDate', () => {
+  describe('formatIntervalToDuration', () => {
     it.each([
       ['10/12/2020', '11/10/2021', '1 year'],
       ['10/12/2016', '10/12/2016', ''],
       ['05/04/2016', '06/04/2016', '1 month'],
       ['03/05/2012', '07/06/2018', '6 years 4 months'],
     ])('should be able to find the difference with years and months', (startDate, endDate, expected) => {
-      const result = SUT.calculateDifferenceInDate(startDate, endDate)
+      const result = SUT.formatIntervalToDuration(startDate, endDate)
       expect(result).toBe(expected)
     })
   })

--- a/src/utils/dates.utils.ts
+++ b/src/utils/dates.utils.ts
@@ -6,9 +6,10 @@ export const formatISOWithFallback =
   (dateString: string, fallback = '') =>
     dateString ? format(parseISO(dateString), formatter) : fallback
 
-export const calculateDifferenceInDate = (startDate: string, endDate: string) => {
+export const formatIntervalToDuration = (startDate: string, endDate: string) => {
   const { years, months } = intervalToDuration({ start: new Date(startDate), end: new Date(endDate) })
   return formatDuration({ years, months })
 }
 
-export const dateToISOString = (e: Date) => e.toISOString()
+export const dateToISOString = (date: Date) => date.toISOString()
+export const newDate = (str: string) => new Date(str)

--- a/src/vendor.d.ts
+++ b/src/vendor.d.ts
@@ -21,6 +21,7 @@ declare module 'ramda' {
   export function identity(...rest: any[]): any
   export function ifElse(...rest: any[]): any
   export function is(...rest: any[]): any
+  export function isEmpty(...rest: any[]): any
   export function isNil(...rest: any[]): any
   export function join(...rest: any[]): any
   export function juxt(...rest: any[]): any
@@ -51,6 +52,7 @@ declare module 'ramda' {
   export function propOr(...rest: any[]): any
   export function reduce(...rest: any[]): any
   export function reduceRight(...rest: any[]): any[]
+  export function reject(...rest: any[]): any
   export function slice(...rest: any[]): any[]
   export function repeat(...rest: any[]): any[]
   export function tail(...rest: any[]): any[]


### PR DESCRIPTION
## Scope [YOMA-586](https://yomaworld.atlassian.net/browse/YOMA-586)
- fix the metadata properties on the selector to show the correct data as per the designs

![](https://media.giphy.com/media/l4EoTFTY0Zn4PvE5O/giphy.gif)
## Work Done
- adding util to format the duration string
- adding util to create an array of metadata strings for the CvViewCredential component. 

## Steps to Test
- run tests
- view in app - should be displaying correctly
    
## Screenshots
<img width="506" alt="Screenshot 2021-09-06 at 23 41 19" src="https://user-images.githubusercontent.com/1424561/132261917-ee3c9ab1-eada-4317-829d-5bc35f7b7ee6.png">
