### PR TITLE
YOMA-598 - test: fixing auth tests after removing notificaiton

### DIFF
--- a/src/modules/Auth/Auth.middleware.test.ts
+++ b/src/modules/Auth/Auth.middleware.test.ts
@@ -422,9 +422,8 @@ describe('modules/Auth/Auth.middleware', () => {
       // given ... the loginSuccess action is fired
       const create = createMiddlewareMock(jest)
       const action = loginSuccess(defaultUserLoginResponseData)
-      const mockNotification = jest.fn()
       // @ts-ignore
-      const { store, invoke, next } = create(SUT.authorizeSuccessFlow({ notification: mockNotification }))
+      const { store, invoke, next } = create(SUT.authorizeSuccessFlow)
 
       // when ... we respond to the loginSuccess action
       invoke(action)
@@ -433,29 +432,13 @@ describe('modules/Auth/Auth.middleware', () => {
       expect(next).toHaveBeenCalledWith(action)
       expect(store.dispatch).toHaveBeenCalled()
     })
-    it('should correctly send a notification to the user', () => {
-      // given ... the login action is fired
-      const create = createMiddlewareMock(jest)
-      // @ts-ignore
-      const action = loginSuccess(defaultUserLoginResponseData)
-      const mockNotification = jest.fn()
-      // @ts-ignore
-      const { invoke } = create(SUT.authorizeSuccessFlow({ notification: mockNotification }))
-
-      // when ... we respond to the login action
-      invoke(action)
-
-      // then ... the login API should be called
-      expect(mockNotification).toHaveBeenCalled()
-    })
     it('should extract and transmit auth credentials and refresh token', () => {
       // given ... the login action is fired
       const create = createMiddlewareMock(jest)
       // @ts-ignore
       const action = loginSuccess(defaultUserLoginResponseData)
-      const mockNotification = jest.fn()
       // @ts-ignores
-      const { store, invoke } = create(SUT.authorizeSuccessFlow({ notification: mockNotification }))
+      const { store, invoke } = create(SUT.authorizeSuccessFlow)
 
       // when ... we respond to the login action
       invoke(action)


### PR DESCRIPTION
## Scope [YOMA-598](https://yomaworld.atlassian.net/browse/YOMA-598)
- by mistake pushed this work straight to develop... 
- this just covers fixing the auth middleware tests after some refactoring (removing notification toast on login as its redundant) 

![](https://media.giphy.com/media/l0G18G3m69vQCOddm/giphy.gif)
## Work Done
- adding validation for Completed Courses
- refactoring Experience form to work the same as Completed Course form
- removing toast on successful login