### PR TITLE
YOMA-585 - refactor(Header): removing clumsy action props

### DIFF
--- a/src/components/Button/Save/ButtonSave.tsx
+++ b/src/components/Button/Save/ButtonSave.tsx
@@ -8,9 +8,9 @@ import styles from './ButtonSave.styles'
 
 interface Props {
   onPress: () => void
-  isDisabled: boolean
+  isDisabled?: boolean
 }
-const ButtonSave = ({ onPress, isDisabled }: Props) => {
+const ButtonSave = ({ onPress, isDisabled = false }: Props) => {
   const { t } = useTranslation()
 
   return (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,49 +4,23 @@ import { View } from 'react-native'
 
 import { types as HomeNavigationTypes } from '../../modules/HomeNavigation'
 import { Colors } from '../../styles'
-import { ButtonAdd, ButtonBack, ButtonSave } from '../Button'
-import Optional from '../Optional'
+import { ButtonBack } from '../Button'
 import Text, { HeaderLevels } from '../Typography'
 import styles from './Header.styles'
 
 type Props = {
   navigation: StackNavigationProp<HomeNavigationTypes.HomeNavigatorParamsList, HomeNavigationTypes.HomeNavigationRoutes>
   headerText: string | React.ReactNode
-  onSave?: () => void
-  showAddButton?: boolean
-  onAdd?: () => void
-  isSaveButtonEnabled?: boolean
   actionItem?: React.ReactNode
 }
 
-const Header = ({
-  navigation,
-  headerText,
-  onSave,
-  showAddButton = false,
-  isSaveButtonEnabled = false,
-  onAdd,
-  actionItem,
-}: Props) => (
+const Header = ({ navigation, headerText, actionItem }: Props) => (
   <View style={styles.container}>
     <ButtonBack onPress={navigation.goBack} />
     <Text.Header level={HeaderLevels.H5} color={Colors.PrimaryPurple}>
       {headerText}
     </Text.Header>
-    <Optional
-      // TODO: refactoring to only expect the actionItem
-      condition={!!actionItem}
-      fallback={
-        <Optional
-          condition={showAddButton}
-          fallback={<ButtonSave onPress={onSave!} isDisabled={!isSaveButtonEnabled} />}
-        >
-          <ButtonAdd onPress={onAdd!} />
-        </Optional>
-      }
-    >
-      {actionItem}
-    </Optional>
+    {actionItem}
   </View>
 )
 

--- a/src/modules/About/About.tsx
+++ b/src/modules/About/About.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { TextInput, View } from 'react-native'
 import { Colors } from 'styles'
 
+import { ButtonSave } from '../../components/Button'
 import Card from '../../components/Card'
 import FormLayout from '../../components/FormLayout'
 import Header from '../../components/Header'
@@ -34,10 +35,9 @@ const About = ({ navigation, onBiographySave, biography }: Props) => {
         }
       />
       <Header
-        isSaveButtonEnabled
         navigation={navigation}
         headerText={t('About')}
-        onSave={() => onBiographySave(userBiography)}
+        actionItem={<ButtonSave onPress={() => onBiographySave(userBiography)} />}
       />
       <Card style={styles.card}>
         <FormLayout>

--- a/src/modules/CompletedChallenges/Form/CompletedChallengesForm.tsx
+++ b/src/modules/CompletedChallenges/Form/CompletedChallengesForm.tsx
@@ -6,6 +6,7 @@ import { View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 
 import { IconInfo } from '../../../assets/images'
+import { ButtonSave } from '../../../components/Button'
 import CheckBoxInput from '../../../components/CheckBoxInput'
 import DateRangeSelect from '../../../components/DateRangeSelect'
 import DropDown from '../../../components/DropDown'
@@ -42,7 +43,11 @@ const CompletedChallengesForm = ({ navigation, challenges, challengesDropDown, f
 
   return (
     <ViewContainer style={styles.container}>
-      <Header navigation={navigation} onSave={form.handleSubmit} headerText={t('Add challenge')} isSaveButtonEnabled />
+      <Header
+        navigation={navigation}
+        headerText={t('Add challenge')}
+        actionItem={<ButtonSave onPress={form.handleSubmit} />}
+      />
       <ScrollView>
         <FormGroup>
           <DropDown name="credentialItemId" label={t('Select a challenge')} items={challengesDropDown} />

--- a/src/modules/CompletedCourses/CompletedCourses.tsx
+++ b/src/modules/CompletedCourses/CompletedCourses.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FlatList, ScrollView } from 'react-native'
 
+import { ButtonAdd, ButtonSave } from '../../components/Button'
 import Card from '../../components/Card'
 import CvViewCredential from '../../components/CvViewCredential'
 import EmptyCard from '../../components/EmptyCard'
@@ -30,9 +31,17 @@ const CompletedCourses = ({ navigation }: Props) => {
             {t('Add course')}
           </Optional>
         }
-        onSave={() => {}}
-        onAdd={() => setIsEditing(true)}
-        showAddButton={!isEditing}
+        actionItem={
+          isEditing ? (
+            <ButtonSave onPress={() => {}} />
+          ) : (
+            <ButtonAdd
+              onPress={() => {
+                setIsEditing(true)
+              }}
+            />
+          )
+        }
       />
       <Optional
         condition={isEditing}

--- a/src/modules/Education/Form/EducationForm.tsx
+++ b/src/modules/Education/Form/EducationForm.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { ScrollView, View } from 'react-native'
 
 import { DropDownTags, FormLayout, InfoModal, Input, Spinner } from '../../../components'
+import { ButtonSave } from '../../../components/Button'
 import Card from '../../../components/Card'
 import CheckBox from '../../../components/CheckBox'
 import DateRangeSelect from '../../../components/DateRangeSelect'
@@ -62,9 +63,7 @@ const EducationForm = forwardRef(({ navigation }: Props, ref) => {
       <Header
         navigation={navigation}
         headerText={t('Education')}
-        isSaveButtonEnabled={isSaveButtonActive}
-        onSave={() => formRef.current?.handleSubmit()}
-        showAddButton={false}
+        actionItem={<ButtonSave onPress={() => formRef.current?.handleSubmit()} isDisabled={!isSaveButtonActive} />}
       />
       <ScrollView>
         <Card>

--- a/src/modules/Experience/Form/ExperienceForm.tsx
+++ b/src/modules/Experience/Form/ExperienceForm.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, TouchableOpacity } from 'react-native'
 
+import { ButtonSave } from '../../../components/Button'
 import Card from '../../../components/Card'
 import CheckBox from '../../../components/CheckBox'
 import DateRangeSelect from '../../../components/DateRangeSelect'
@@ -34,7 +35,11 @@ const ExperienceForm = ({ navigation, skills, organisations, onFilterSkills, for
 
   return (
     <ViewContainer style={styles.container}>
-      <Header navigation={navigation} headerText={t('Experience')} onSave={form.handleSubmit} isSaveButtonEnabled />
+      <Header
+        navigation={navigation}
+        headerText={t('Experience')}
+        actionItem={<ButtonSave onPress={form.handleSubmit} />}
+      />
       <ScrollView>
         <Card>
           <FormLayout>

--- a/src/modules/MySkills/Form/MySkillsForm.tsx
+++ b/src/modules/MySkills/Form/MySkillsForm.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { View } from 'react-native'
 
+import { ButtonSave } from '../../../components/Button'
 import Header from '../../../components/Header'
 import { HomeNavigationRoutes, HomeNavigatorParamsList } from '../../HomeNavigation/HomeNavigation.types'
 import { MOCK_USER_SKILLS_LIST, USER_SKILLS_INITIAL_VALUES } from './MySkillsForm.constants'
@@ -18,7 +19,7 @@ const MySkillsForm = ({ navigation }: Props) => {
 
   return (
     <ViewContainer style={styles.container}>
-      <Header navigation={navigation} headerText={t('Add skill')} onSave={() => {}} />
+      <Header navigation={navigation} headerText={t('Add skill')} actionItem={<ButtonSave onPress={() => {}} />} />
       <Card>
         <Formik initialValues={USER_SKILLS_INITIAL_VALUES} onSubmit={() => {}}>
           {(formikHandlers: FormikProps<FormikValues>) => (

--- a/src/modules/Profile/Profile.tsx
+++ b/src/modules/Profile/Profile.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { Image, ScrollView, TouchableOpacity, View } from 'react-native'
 
 import { EditIcon } from '../../assets/images'
-import Button, { ButtonVariants } from '../../components/Button'
+import Button, { ButtonSave, ButtonVariants } from '../../components/Button'
 import Card from '../../components/Card'
 import Header from '../../components/Header'
 import Optional from '../../components/Optional'
@@ -43,7 +43,11 @@ const Profile = ({ navigation, onLogoutUser, onPhotoSave, onProfileSave, user }:
 
   return (
     <ViewContainer style={styles.container}>
-      <Header isSaveButtonEnabled navigation={navigation} headerText={'Profile'} onSave={handleProfileForm} />
+      <Header
+        navigation={navigation}
+        headerText={t('Profile')}
+        actionItem={<ButtonSave onPress={handleProfileForm} isDisabled={!formState?.isValid} />}
+      />
       <ScrollView>
         <Card style={styles.card}>
           <Optional


### PR DESCRIPTION
## Scope [YOMA-585](https://yomaworld.atlassian.net/browse/YOMA-585)

We used to have 4 or 5 props to handle the single action item (which was hard-coded to either be a save button or add button). I've refactored it to take an 'action' component, that can be anything. This moves control to the parent component.

![](https://media.giphy.com/media/l41Ym9MjGghKfwc5G/giphy.gif)
## Work Done
- refactored all components affected to use the actionItem prop and pass in a ButtonSave or ButtonAdd component.

## Steps to Test
- ensure tests are working, 
- run through Profile, About, and the other MyCV screen views and ensure the headers look correct and buttons haven't regressed at all.