### PR TITLE
YOMA-590 - Part 5 - refactor(Cv modules): refactoring and updating the Modules

### DIFF
--- a/src/modules/CompletedChallenges/CompletedChallenges.tsx
+++ b/src/modules/CompletedChallenges/CompletedChallenges.tsx
@@ -1,25 +1,21 @@
-import { NativeStackNavigationProp } from '@react-navigation/native-stack'
-import React, { useState } from 'react'
+import React from 'react'
 
-import Optional from '../../components/Optional'
-import { HomeNavigationRoutes, HomeNavigatorParamsList } from '../HomeNavigation/HomeNavigation.types'
-import CompletedChallengesForm from './Form'
+import { CompleteChallengesNavigation } from '~/modules/CompletedChallenges/types'
+import { HomeNavigationRoutes } from '~/modules/HomeNavigation/HomeNavigation.types'
+
 import CompletedChallengesView from './View'
 
 interface Props {
-  navigation: NativeStackNavigationProp<HomeNavigatorParamsList, HomeNavigationRoutes.CompletedChallenges>
+  navigation: CompleteChallengesNavigation
 }
 
-const CompletedChallenges = ({ navigation }: Props) => {
-  const [isEditing, setIsEditing] = useState(false)
-
-  const handleAdd = () => setIsEditing(true)
-
-  return (
-    <Optional condition={isEditing} fallback={<CompletedChallengesView onAdd={handleAdd} navigation={navigation} />}>
-      <CompletedChallengesForm navigation={navigation} />
-    </Optional>
-  )
-}
+const CompletedChallenges = ({ navigation }: Props) => (
+  <CompletedChallengesView
+    onAdd={() => {
+      navigation.navigate(HomeNavigationRoutes.CompletedChallengesForm)
+    }}
+    navigation={navigation}
+  />
+)
 
 export default CompletedChallenges

--- a/src/modules/CompletedChallenges/Form/ChallengeInfo/ChallengeInfo.styles.ts
+++ b/src/modules/CompletedChallenges/Form/ChallengeInfo/ChallengeInfo.styles.ts
@@ -1,7 +1,6 @@
 import { StyleSheet, ViewStyle } from 'react-native'
 
-import { Colors, colors } from '../../../../styles'
-import { utils as StyleUtils } from '../../../../styles'
+import { Colors, utils as StyleUtils, colors } from '~/styles'
 
 const styles = {
   container: {

--- a/src/modules/CompletedChallenges/Form/ChallengeInfo/ChallengeInfo.tsx
+++ b/src/modules/CompletedChallenges/Form/ChallengeInfo/ChallengeInfo.tsx
@@ -4,8 +4,8 @@ import { View } from 'react-native'
 import Optional from '~/components/Optional'
 import Spacer from '~/components/Spacer'
 import Text, { Bold, HeaderLevels } from '~/components/Typography'
+import { Challenge } from '~/modules/Challenges/Challenges.types'
 
-import { Challenge } from '../../../Challenges/Challenges.types'
 import styles from './ChallengeInfo.styles'
 
 interface Props {

--- a/src/modules/CompletedChallenges/Form/CompletedChallengesForm.container.tsx
+++ b/src/modules/CompletedChallenges/Form/CompletedChallengesForm.container.tsx
@@ -1,11 +1,10 @@
-import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { Formik } from 'formik'
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
+import { CompleteChallengesNavigation } from '~/modules/CompletedChallenges/types'
 import * as FormUtils from '~/utils/form.utils'
 
-import { HomeNavigationRoutes, HomeNavigatorParamsList } from '../../HomeNavigation/HomeNavigation.types'
 import { actions as UserChallengesActions } from '../../UserChallenges'
 import { schema } from './CompletedChallengeForm.validation'
 import CompletedChallengesForm from './CompletedChallengesForm'
@@ -14,7 +13,7 @@ import selector from './CompletedChallengesForm.selector'
 import { FormFields } from './CompletedChallengesForm.types'
 
 interface Props {
-  navigation: NativeStackNavigationProp<HomeNavigatorParamsList, HomeNavigationRoutes.CompletedChallenges>
+  navigation: CompleteChallengesNavigation
 }
 const CompletedChallengesFormContainer = ({ navigation }: Props) => {
   const { challenges, challengesDropDown } = useSelector(selector)

--- a/src/modules/CompletedChallenges/Form/CompletedChallengesForm.selector.test.ts
+++ b/src/modules/CompletedChallenges/Form/CompletedChallengesForm.selector.test.ts
@@ -1,10 +1,11 @@
-import { rootStateFixture } from '../../../redux/redux.fixture'
-import { challengesStateFixture } from '../../Challenges/Challenges.fixture'
+import { challengesStateFixture } from '~/modules/Challenges/Challenges.fixture'
+import { rootStateFixture } from '~/redux/redux.fixture'
+
 import SUT from './CompletedChallengesForm.selector'
 
 describe('modules/CompletedChallenges/Form/CompletedChallengesForm.selector', () => {
   describe('selector', () => {
-    it(`should return empty data for challenges and dropdown data, 
+    it(`should return empty data for challenges and dropdown data,
     when we load the completed challenges form, given an empty state`, () => {
       // given ... an empty state
       const stateMock = rootStateFixture()

--- a/src/modules/CompletedChallenges/Form/CompletedChallengesForm.styles.ts
+++ b/src/modules/CompletedChallenges/Form/CompletedChallengesForm.styles.ts
@@ -1,7 +1,6 @@
 import { StyleSheet, ViewStyle } from 'react-native'
 
-import { Colors, colors } from '../../../styles'
-import { utils as StyleUtils } from '../../../styles'
+import { Colors, utils as StyleUtils, colors } from '~/styles'
 
 const styles = {
   container: {

--- a/src/modules/CompletedChallenges/View/CompletedChallengesView.container.tsx
+++ b/src/modules/CompletedChallenges/View/CompletedChallengesView.container.tsx
@@ -1,17 +1,18 @@
-import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import React from 'react'
 import { useSelector } from 'react-redux'
 
-import { HomeNavigationRoutes, HomeNavigatorParamsList } from '../../HomeNavigation/HomeNavigation.types'
+import { CompleteChallengesNavigation } from '~/modules/CompletedChallenges/types'
+
 import CompletedChallengesView from './CompletedChallengesView'
 import selector from './CompletedChallengesView.selector'
 
 interface Props {
   onAdd: () => void
-  navigation: NativeStackNavigationProp<HomeNavigatorParamsList, HomeNavigationRoutes.CompletedChallenges>
+  navigation: CompleteChallengesNavigation
 }
 const CompletedChallengesViewContainer = ({ onAdd, navigation }: Props) => {
   const { userChallenges } = useSelector(selector)
+
   return <CompletedChallengesView onAdd={onAdd} navigation={navigation} userChallenges={userChallenges} />
 }
 

--- a/src/modules/CompletedChallenges/View/CompletedChallengesView.selector.test.ts
+++ b/src/modules/CompletedChallenges/View/CompletedChallengesView.selector.test.ts
@@ -1,5 +1,6 @@
-import { rootStateFixture } from '../../../redux/redux.fixture'
-import { USER_CHALLENGES_STATE_MOCK } from '../../UserChallenges/UserChallenges.fixtures'
+import { USER_CHALLENGES_STATE_MOCK } from '~/modules/UserChallenges/UserChallenges.fixtures'
+import { rootStateFixture } from '~/redux/redux.fixture'
+
 import * as SUT from './CompletedChallengesView.selector'
 
 describe('modules/CompletedChallenges/CompletedChallengesView/CompletedChallengesView.selector', () => {

--- a/src/modules/CompletedChallenges/View/CompletedChallengesView.tsx
+++ b/src/modules/CompletedChallenges/View/CompletedChallengesView.tsx
@@ -20,7 +20,7 @@ const CompletedChallengesView = ({ onAdd, userChallenges, navigation }: Props) =
     <CvView
       title={t('Challenges')}
       noDataMessage={t('Have you completed any challenges yet?')}
-      onAdd={onAdd}
+      onAction={onAdd}
       navigation={navigation}
     >
       <CvViewList data={userChallenges} RenderItem={CvViewCredential} />

--- a/src/modules/CompletedChallenges/View/CompletedChallengesView.utils.test.ts
+++ b/src/modules/CompletedChallenges/View/CompletedChallengesView.utils.test.ts
@@ -1,6 +1,7 @@
 import { mergeDeepRight } from 'ramda'
 
-import { USER_CHALLENGES_RESPONSE_MOCK } from '../../UserChallenges/UserChallenges.fixtures'
+import { USER_CHALLENGES_RESPONSE_MOCK } from '~/modules/UserChallenges/UserChallenges.fixtures'
+
 import * as SUT from './CompletedChallengesView.utils'
 
 describe('modules/CompletedChallenges/CompletedChallengesView/CompletedChallengesView.utils', () => {

--- a/src/modules/CompletedChallenges/View/CompletedChallengesView.utils.ts
+++ b/src/modules/CompletedChallenges/View/CompletedChallengesView.utils.ts
@@ -1,6 +1,6 @@
 import { applySpec, compose, isEmpty, pathOr, pick, pipe, reject, values } from 'ramda'
 
-import { formatStartEndString } from '../../../utils/dates.utils'
+import { formatStartEndString } from '~/utils/dates.utils'
 
 export const getCompletedChallengesMetadata = pipe(
   applySpec({

--- a/src/modules/CompletedChallenges/Widget/CompletedChallengesWidget.selector.test.ts
+++ b/src/modules/CompletedChallenges/Widget/CompletedChallengesWidget.selector.test.ts
@@ -1,5 +1,6 @@
-import { rootStateFixture } from '../../../redux/redux.fixture'
-import { INITIAL_STATE } from '../../UserChallenges/UserChallenges.reducer'
+import { INITIAL_STATE } from '~/modules/UserChallenges/UserChallenges.reducer'
+import { rootStateFixture } from '~/redux/redux.fixture'
+
 import * as SUT from './CompletedChallengesWidget.selector'
 
 describe('modules/CompletedChallenges/CompletedChallengesWidget/CompletedChallengesWidget.selector', () => {

--- a/src/modules/CompletedChallenges/Widget/CompletedChallengesWidget.tsx
+++ b/src/modules/CompletedChallenges/Widget/CompletedChallengesWidget.tsx
@@ -1,26 +1,27 @@
-import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
 import CvWidget, { CvWidgetList } from '~/components/CvWidget'
 import CvWidgetCredential, { types as CvWidgetCredentialTypes } from '~/components/CvWidgetCredential'
-import { HomeNavigationRoutes, HomeNavigatorParamsList } from '~/modules/HomeNavigation/HomeNavigation.types'
+import { HomeNavigationRoutes } from '~/modules/HomeNavigation/HomeNavigation.types'
+import { types as MyCvTypes } from '~/modules/MyCv'
 import { Colors } from '~/styles'
 
 interface Props {
   userChallenges: CvWidgetCredentialTypes.NormalisedCvWidgetCredentialItems
   count: number
-  navigation: NativeStackNavigationProp<HomeNavigatorParamsList, HomeNavigationRoutes.MyCv>
+  navigation: MyCvTypes.MyCvNavigation
 }
 const CompletedChallengesWidget = ({ userChallenges, count, navigation }: Props) => {
   const { t } = useTranslation()
+
   return (
     <CvWidget
       count={count}
       badgeColor={Colors.SecondaryPurple}
       title={t('Completed challenges')}
       noDataMessage={t('Have you completed any challenges yet?')}
-      onAction={() => {
+      onActionPress={() => {
         navigation.navigate(HomeNavigationRoutes.CompletedChallengesForm)
       }}
     >

--- a/src/modules/CompletedChallenges/types.ts
+++ b/src/modules/CompletedChallenges/types.ts
@@ -1,0 +1,8 @@
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
+
+import { HomeNavigationRoutes, HomeNavigatorParamsList } from '~/modules/HomeNavigation/HomeNavigation.types'
+
+export type CompleteChallengesNavigation = NativeStackNavigationProp<
+  HomeNavigatorParamsList,
+  HomeNavigationRoutes.CompletedChallenges
+>

--- a/src/modules/Education/Education.tsx
+++ b/src/modules/Education/Education.tsx
@@ -1,25 +1,21 @@
-import { NativeStackNavigationProp } from '@react-navigation/native-stack'
-import React, { useState } from 'react'
+import React from 'react'
 
-import Optional from '../../components/Optional'
-import { HomeNavigationRoutes, HomeNavigatorParamsList } from '../HomeNavigation/HomeNavigation.types'
-import EducationForm from './Form'
+import { EducationNavigation } from '~/modules/Education/types'
+import { HomeNavigationRoutes } from '~/modules/HomeNavigation/HomeNavigation.types'
+
 import EducationView from './View'
 
 interface Props {
-  navigation: NativeStackNavigationProp<HomeNavigatorParamsList, HomeNavigationRoutes.Education>
+  navigation: EducationNavigation
 }
 
-const Education = ({ navigation }: Props) => {
-  const [isEditing, setIsEditing] = useState(false)
-
-  const handleAdd = () => setIsEditing(true)
-
-  return (
-    <Optional condition={isEditing} fallback={<EducationView onAdd={handleAdd} navigation={navigation} />}>
-      <EducationForm navigation={navigation} />
-    </Optional>
-  )
-}
+const Education = ({ navigation }: Props) => (
+  <EducationView
+    onAdd={() => {
+      navigation.navigate(HomeNavigationRoutes.EducationForm)
+    }}
+    navigation={navigation}
+  />
+)
 
 export default Education

--- a/src/modules/Education/View/EducationView.container.tsx
+++ b/src/modules/Education/View/EducationView.container.tsx
@@ -1,17 +1,18 @@
-import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import React from 'react'
 import { useSelector } from 'react-redux'
 
-import { HomeNavigationRoutes, HomeNavigatorParamsList } from '../../HomeNavigation/HomeNavigation.types'
+import { EducationNavigation } from '~/modules/Education/types'
+
 import EducationView from './EducationView'
 import selector from './EducationView.selector'
 
 interface Props {
   onAdd: () => void
-  navigation: NativeStackNavigationProp<HomeNavigatorParamsList, HomeNavigationRoutes.Education>
+  navigation: EducationNavigation
 }
 const EducationViewContainer = ({ onAdd, navigation }: Props) => {
   const { userQualifications } = useSelector(selector)
+
   return <EducationView onAdd={onAdd} navigation={navigation} userQualifications={userQualifications} />
 }
 

--- a/src/modules/Education/View/EducationView.selector.test.ts
+++ b/src/modules/Education/View/EducationView.selector.test.ts
@@ -1,5 +1,6 @@
-import { rootStateFixture } from '../../../redux/redux.fixture'
-import { USER_QUALIFICATIONS_STATE_MOCK } from '../../UserQualifications/UserQualifications.fixture'
+import { USER_QUALIFICATIONS_STATE_MOCK } from '~/modules/UserQualifications/UserQualifications.fixture'
+import { rootStateFixture } from '~/redux/redux.fixture'
+
 import * as SUT from './EducationView.selector'
 
 describe('modules/Education/EducationView/EducationView.selector', () => {

--- a/src/modules/Education/View/EducationView.selector.ts
+++ b/src/modules/Education/View/EducationView.selector.ts
@@ -2,9 +2,9 @@ import { createSelector } from '@reduxjs/toolkit'
 import { applySpec, map, path, pathOr, pipe, propOr } from 'ramda'
 
 import { types as CvViewCredentialTypes } from '~/components/CvViewCredential'
+import { selectUserQualifications } from '~/modules/UserQualifications/UserQualifications.selector'
 import { NormalisedUserQualifications } from '~/modules/UserQualifications/UserQualifications.types'
 
-import { selectUserQualifications } from '../../UserQualifications/UserQualifications.selector'
 import { getEducationMetadata } from './EducationView.utils'
 
 export default createSelector<any, { userQualifications: CvViewCredentialTypes.CvViewCredentialsData }>(

--- a/src/modules/Education/View/EducationView.tsx
+++ b/src/modules/Education/View/EducationView.tsx
@@ -4,8 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import CvView, { CvViewList } from '~/components/CvView'
 import CvViewCredential, { types as CvViewCredentialTypes } from '~/components/CvViewCredential'
-
-import { HomeNavigationRoutes, HomeNavigatorParamsList } from '../../HomeNavigation/HomeNavigation.types'
+import { HomeNavigationRoutes, HomeNavigatorParamsList } from '~/modules/HomeNavigation/HomeNavigation.types'
 
 interface Props {
   onAdd: () => void
@@ -19,7 +18,7 @@ const EducationView = ({ onAdd, navigation, userQualifications }: Props) => {
     <CvView
       title={t('Education')}
       noDataMessage={t('Which school, university or college did you attend?')}
-      onAdd={onAdd}
+      onAction={onAdd}
       navigation={navigation}
     >
       <CvViewList data={userQualifications} RenderItem={CvViewCredential} />

--- a/src/modules/Education/View/EducationView.utils.test.ts
+++ b/src/modules/Education/View/EducationView.utils.test.ts
@@ -1,6 +1,7 @@
 import { mergeDeepRight } from 'ramda'
 
-import { USER_QUALIFICATIONS_MOCK } from '../../UserQualifications/UserQualifications.fixture'
+import { USER_QUALIFICATIONS_MOCK } from '~/modules/UserQualifications/UserQualifications.fixture'
+
 import * as SUT from './EducationView.utils'
 
 describe('modules/Education/Education.utils', () => {

--- a/src/modules/Education/View/EducationView.utils.ts
+++ b/src/modules/Education/View/EducationView.utils.ts
@@ -1,7 +1,7 @@
 import { applySpec, compose, isEmpty, pipe, propOr, reject, unless, values } from 'ramda'
 
-import { DATE_TPL_MON_YEAR } from '../../../constants/date.constants'
-import { formatDateString } from '../../../utils/dates.utils'
+import { DATE_TPL_MON_YEAR } from '~/constants/date.constants'
+import { formatDateString } from '~/utils/dates.utils'
 
 export const getEducationMetadata = pipe(
   applySpec({

--- a/src/modules/Education/Widget/EducationWidget.selector.test.ts
+++ b/src/modules/Education/Widget/EducationWidget.selector.test.ts
@@ -1,5 +1,6 @@
-import { rootStateFixture } from '../../../redux/redux.fixture'
-import { USER_QUALIFICATIONS_STATE_MOCK } from '../../UserQualifications/UserQualifications.fixture'
+import { USER_QUALIFICATIONS_STATE_MOCK } from '~/modules/UserQualifications/UserQualifications.fixture'
+import { rootStateFixture } from '~/redux/redux.fixture'
+
 import * as SUT from './EducationWidget.selector'
 
 describe('modules/Education/EducationWidget/EducationWidget.selector', () => {

--- a/src/modules/Education/Widget/EducationWidget.selector.ts
+++ b/src/modules/Education/Widget/EducationWidget.selector.ts
@@ -1,22 +1,27 @@
 import { createSelector } from '@reduxjs/toolkit'
 import { applySpec, map, path, pathOr, pick, pipe, propOr, slice } from 'ramda'
 
-import { selectUserQualificationCredentials } from '../../UserQualifications/UserQualifications.selector'
+import { NormalisedCvWidgetCredentialItems } from '~/components/CvWidgetCredential/CvWidgetCredential.types'
+import { selectUserQualificationCredentials } from '~/modules/UserQualifications/UserQualifications.selector'
+import { NormalisedUserQualifications } from '~/modules/UserQualifications/UserQualifications.types'
 
-export default createSelector(selectUserQualificationCredentials, userQualifications => {
-  const count = userQualifications.ids.length
-  const ids = slice(0, 2, userQualifications.ids)
-  const entities = pipe(
-    pick(ids),
-    map(
-      applySpec({
-        name: pathOr('', ['qualification', 'title']),
-        startDate: propOr('', 'startDate'),
-        organisationLogoURL: path(['qualification', 'organisationLogoURL']),
-        isValidated: propOr(false, 'approved'),
-      }),
-    ),
-  )(userQualifications.entities)
+export default createSelector<any, { userQualifications: NormalisedCvWidgetCredentialItems; count: number }>(
+  selectUserQualificationCredentials,
+  (userQualifications: NormalisedUserQualifications) => {
+    const count = userQualifications.ids.length
+    const ids = slice(0, 2, userQualifications.ids)
+    const entities = pipe(
+      pick(ids),
+      map(
+        applySpec({
+          name: pathOr('', ['qualification', 'title']),
+          startDate: propOr('', 'startDate'),
+          organisationLogoURL: path(['qualification', 'organisationLogoURL']),
+          isValidated: propOr(false, 'approved'),
+        }),
+      ),
+    )(userQualifications.entities)
 
-  return { userQualifications: { ids, entities }, count }
-})
+    return { userQualifications: { ids, entities }, count }
+  },
+)

--- a/src/modules/Education/Widget/EducationWidget.tsx
+++ b/src/modules/Education/Widget/EducationWidget.tsx
@@ -15,13 +15,14 @@ interface Props {
 
 const EducationWidget = ({ userQualifications, count, navigation }: Props) => {
   const { t } = useTranslation()
+
   return (
     <CvWidget
       count={count}
       badgeColor={Colors.PrimaryRed}
       title={t('Education')}
       noDataMessage={t('Which school, university or college did you attend?')}
-      onAction={() => {
+      onActionPress={() => {
         navigation.navigate(HomeNavigationRoutes.EducationForm)
       }}
     >

--- a/src/modules/Education/types.ts
+++ b/src/modules/Education/types.ts
@@ -1,0 +1,5 @@
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
+
+import { HomeNavigationRoutes, HomeNavigatorParamsList } from '~/modules/HomeNavigation/HomeNavigation.types'
+
+export type EducationNavigation = NativeStackNavigationProp<HomeNavigatorParamsList, HomeNavigationRoutes.Education>

--- a/src/modules/Experience/Experience.tsx
+++ b/src/modules/Experience/Experience.tsx
@@ -9,15 +9,13 @@ interface Props {
   navigation: ExperienceNavigation
 }
 
-const Experience = ({ navigation }: Props) => {
-  return (
-    <ExperienceView
-      onAdd={() => {
-        navigation.navigate(HomeNavigationRoutes.ExperienceForm)
-      }}
-      navigation={navigation}
-    />
-  )
-}
+const Experience = ({ navigation }: Props) => (
+  <ExperienceView
+    onAdd={() => {
+      navigation.navigate(HomeNavigationRoutes.ExperienceForm)
+    }}
+    navigation={navigation}
+  />
+)
 
 export default Experience

--- a/src/modules/Experience/View/ExperienceView.tsx
+++ b/src/modules/Experience/View/ExperienceView.tsx
@@ -18,7 +18,7 @@ const ExperienceView = ({ userJobs, navigation, onAdd }: Props) => {
     <CvView
       title={t('Experience')}
       noDataMessage={t('Where do you currently work?')}
-      onAdd={onAdd}
+      onAction={onAdd}
       navigation={navigation}
     >
       <CvViewList data={userJobs} RenderItem={CvViewCredential} />

--- a/src/modules/Experience/Widget/ExperienceWidget.tsx
+++ b/src/modules/Experience/Widget/ExperienceWidget.tsx
@@ -21,7 +21,7 @@ const ExperienceWidget = ({ userJobs, count, navigation }: Props) => {
       badgeColor={Colors.SecondaryPurple}
       title={t('Experience')}
       noDataMessage={t('Where do you currently work?')}
-      onAction={() => {
+      onActionPress={() => {
         navigation.navigate(HomeNavigationRoutes.ExperienceForm)
       }}
     >

--- a/src/modules/MySkills/MySkills.tsx
+++ b/src/modules/MySkills/MySkills.tsx
@@ -1,31 +1,21 @@
-import { NativeStackNavigationProp } from '@react-navigation/native-stack'
-import React, { useState } from 'react'
+import React from 'react'
 
-import Optional from '~/components/Optional'
+import { HomeNavigationRoutes } from '~/modules/HomeNavigation/HomeNavigation.types'
+import { MySkillsNavigation } from '~/modules/MySkills/types'
 
-import { types as HomeNavigationTypes } from '../HomeNavigation'
-import SkillsForm from './Form'
 import MySkillsView from './View'
 
 interface Props {
-  navigation: NativeStackNavigationProp<
-    HomeNavigationTypes.HomeNavigatorParamsList,
-    HomeNavigationTypes.HomeNavigationRoutes.MySkills
-  >
+  navigation: MySkillsNavigation
 }
 
-const MySkills = ({ navigation }: Props) => {
-  const [isEditing, setIsEditing] = useState(false)
-
-  const handleAddUserSkills = () => {
-    setIsEditing(true)
-  }
-
-  return (
-    <Optional condition={isEditing} fallback={<MySkillsView navigation={navigation} onAdd={handleAddUserSkills} />}>
-      <SkillsForm navigation={navigation} />
-    </Optional>
-  )
-}
+const MySkills = ({ navigation }: Props) => (
+  <MySkillsView
+    onAdd={() => {
+      navigation.navigate(HomeNavigationRoutes.MySkillsForm)
+    }}
+    navigation={navigation}
+  />
+)
 
 export default MySkills

--- a/src/modules/MySkills/View/MySkillsView.container.tsx
+++ b/src/modules/MySkills/View/MySkillsView.container.tsx
@@ -1,18 +1,19 @@
-import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import React from 'react'
 import { useSelector } from 'react-redux'
 
-import { HomeNavigationRoutes, HomeNavigatorParamsList } from '../../HomeNavigation/HomeNavigation.types'
+import { MySkillsNavigation } from '~/modules/MySkills/types'
+
 import MySkillsView from './MySkillsView'
 import selector from './MySkillsView.selector'
 
 interface Props {
   onAdd: () => void
-  navigation: NativeStackNavigationProp<HomeNavigatorParamsList, HomeNavigationRoutes.MySkills>
+  navigation: MySkillsNavigation
 }
 
 const MySkillsViewContainer = ({ navigation, onAdd }: Props) => {
   const { userSkills } = useSelector(selector)
+
   return <MySkillsView userSkills={userSkills} onAdd={onAdd} navigation={navigation} />
 }
 

--- a/src/modules/MySkills/View/MySkillsView.tsx
+++ b/src/modules/MySkills/View/MySkillsView.tsx
@@ -24,7 +24,7 @@ const MySkillsView = ({ userSkills, onAdd, navigation }: Props) => {
     <CvView
       title={t('Skills')}
       noDataMessage={t('Tell us what you are great at.')}
-      onAdd={onAdd}
+      onAction={onAdd}
       navigation={navigation}
     >
       <View style={styles.container}>

--- a/src/modules/MySkills/Widget/MySkillsWidget.tsx
+++ b/src/modules/MySkills/Widget/MySkillsWidget.tsx
@@ -21,7 +21,7 @@ const MySkillsWidget = ({ userSkills, count, navigation }: Props) => {
       badgeColor={Colors.PrimaryGreen}
       title={t('My skills')}
       noDataMessage={t('Tell us what you are great at.')}
-      onAction={() => {
+      onActionPress={() => {
         navigation.navigate(HomeNavigationRoutes.MySkillsForm)
       }}
     >

--- a/src/modules/MySkills/types.ts
+++ b/src/modules/MySkills/types.ts
@@ -1,0 +1,5 @@
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
+
+import { HomeNavigationRoutes, HomeNavigatorParamsList } from '~/modules/HomeNavigation/HomeNavigation.types'
+
+export type MySkillsNavigation = NativeStackNavigationProp<HomeNavigatorParamsList, HomeNavigationRoutes.MySkills>


### PR DESCRIPTION
## Scope [YOMA-590](https://yomaworld.atlassian.net/browse/YOMA-590)

![](https://media.giphy.com/media/3osxYi519vegIOIbPW/giphy.gif)

## Work Done
- typing navigation for the widgets
- implementing the renamed onAction to onActionPress
- implementing adjusted `onAdd` to `onAction`
- adding better typing for selectors 
- some general refactors and cleanup