### PR TITLE
YOMA-699, YOMA-698 - refactor(About): remove find inspiration, updating View All text on widget

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -139,7 +139,7 @@ android {
         applicationId "com.yomamobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 79
+        versionCode 80
         versionName "1.0.0"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
         manifestPlaceholders = [appAuthRedirectScheme: 'com.yomamobile.auth']

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,8 +1,9 @@
 Ver 0.0.1
 Latest:
-- Fixing update email on profile update.
+- Removing 'info' section in About form, updating About widget 'View All' to 'View Full Biography'
 
 Previous deployment release notes:
+- Fixing update email on profile update.
 - adding generic banner
 - creating WorkExperience credentials, updated Widgets to 'Work Experience'
 - Fixing Skills selector (can select multiple skills)

--- a/src/components/BannerCard/BannerCard.styles.ts
+++ b/src/components/BannerCard/BannerCard.styles.ts
@@ -3,6 +3,7 @@ import { StyleSheet, ViewStyle } from 'react-native'
 const styles = {
   container: {
     overflow: 'hidden',
+    marginTop: 0,
   } as ViewStyle,
   backgroundImage: {
     position: 'absolute',

--- a/src/components/Card/Card.styles.ts
+++ b/src/components/Card/Card.styles.ts
@@ -7,9 +7,7 @@ const styles = {
     backgroundColor: colors[Colors.White],
     borderRadius: 12,
     elevation: 3,
-    marginHorizontal: 10,
-    marginBottom: 10,
-    marginTop: 0,
+    margin: 10,
   } as ViewStyle,
 }
 

--- a/src/modules/About/Form/AboutForm.tsx
+++ b/src/modules/About/Form/AboutForm.tsx
@@ -1,19 +1,15 @@
 import { FormikProps } from 'formik'
-import React, { useState } from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 
 import { ButtonSave } from '~/components/Button'
 import Card from '~/components/Card'
 import FormLayout from '~/components/FormLayout'
 import Header from '~/components/Header'
-import InfoModal from '~/components/InfoModal'
 import Input from '~/components/Input'
-import Text, { MetaLevels } from '~/components/Typography'
 import ViewContainer from '~/components/ViewContainer'
 import { AboutNavigation } from '~/modules/About/types'
-import { Colors } from '~/styles'
 
 import styles from './AboutForm.styles'
 
@@ -24,17 +20,9 @@ interface Props {
 
 const AboutForm = ({ navigation, form }: Props) => {
   const { t } = useTranslation()
-  const [infoModal, setInfoModal] = useState(false)
 
   return (
     <ViewContainer style={styles.container}>
-      <InfoModal
-        visible={infoModal}
-        closeModal={() => setInfoModal(false)}
-        infoText={
-          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec quis mauris purus. Quisque malesuada ornare mauris sed feugiat. Cras lectus est, iaculis quis nulla cursus, finibus gravida massa. Donec condimentum porta nisi, eu egestas risus ullamcorper in. In et magna mauris. '
-        }
-      />
       <Header
         navigation={navigation}
         headerText={t('about.title')}
@@ -44,11 +32,6 @@ const AboutForm = ({ navigation, form }: Props) => {
         <Card style={styles.card}>
           <FormLayout>
             <Input name={'biography'} label={t('Summary')} multiline maxLength={1000} returnKeyType="done" />
-            <View style={styles.bottom}>
-              <Text.Meta level={MetaLevels.SmallBold} color={Colors.PrimaryGreen} onPress={() => setInfoModal(true)}>
-                {t('Find inspiration on how to write a great education description.')}
-              </Text.Meta>
-            </View>
           </FormLayout>
         </Card>
       </ScrollView>

--- a/src/modules/About/Widget/AboutWidget.tsx
+++ b/src/modules/About/Widget/AboutWidget.tsx
@@ -38,7 +38,7 @@ const AboutWidget = ({ biography, navigation }: Props) => {
           <Text.Body>{biographyShort}</Text.Body>
         </Pressable>
         <Divider />
-        <Button label={t('View All')} variant={ButtonVariants.Clear} onPress={onViewAllNavigate} />
+        <Button label={t('View Full Biography')} variant={ButtonVariants.Clear} onPress={onViewAllNavigate} />
       </View>
     </CvWidget>
   )


### PR DESCRIPTION
## Scope [YOMA-699](https://yomaworld.atlassian.net/browse/YOMA-699) | [YOMA-698](https://yomaworld.atlassian.net/browse/YOMA-698)

![](https://media.giphy.com/media/C7olQswvzSwAE/giphy.gif)
## Work Done
- removing 'find inspiration' link and modal.
- adjusting View All text in widget to 'View Full Biography'

## Steps to Test
- Open app on MyCV - check Widget 'View All' text
- click edit pencil on About widget, see that there is no 'inspiration' link at bottom of field.
    
## Screenshots
<img width="452" alt="Screenshot 2022-11-02 at 22 22 46" src="https://user-images.githubusercontent.com/1424561/199594957-8c2e50f8-266f-4ba8-8f46-197b53cfccc6.png">
